### PR TITLE
Add bin field in package.json

### DIFF
--- a/.changeset/wet-clocks-crash.md
+++ b/.changeset/wet-clocks-crash.md
@@ -1,0 +1,5 @@
+---
+"@himanoa/class-name-extractor": patch
+---
+
+Enable external execution of the class-name-extractor

--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
     "access": "public",
     "registry": "https://registry.npmjs.org/"
   },
+  "bin": {
+    "class-name-extractor": "dist/main.cjs"
+  },
   "scripts": {
     "test": "spago test",
     "build": "spago build && esbuild --bundle --platform=node main.mjs > dist/main.cjs && chmod +x dist/main.cjs",


### PR DESCRIPTION
The CLI tool cannot be called externally unless the bin field is specified.
